### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,8 +1,8 @@
 # Datatypes/Classes (KEYWORD1)
 
 # Public methods (KEYWORD2)
-serialEvent KEYWORD2
-freeRam KEYWORD2
+serialEvent	KEYWORD2
+freeRam	KEYWORD2
 
 # Constants (LITERAL1)
-LOOP_COUNT LITERAL1
+LOOP_COUNT	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords